### PR TITLE
Fix file leak in convertIntelligent after rename

### DIFF
--- a/video.go
+++ b/video.go
@@ -23,7 +23,7 @@ type Media struct {
 	ACodec   string         `json:"acodec"`
 	Path     string
 	FileName string
-	Title    string         `json:"title"`
+	Title    string `json:"title"`
 
 	randomName  string
 	tmpDir      string
@@ -593,13 +593,14 @@ func (media *Media) convertIntelligent(analysis *MediaAnalysis) error {
 			float64(newFileInfo.Size())/(1024*1024))
 	}
 
-	media.Path = outputPath
-	media.FileName = outputFileName
-
-	// Clean up original file
-	if err := os.Remove(filepath.Join(media.tmpDir, media.randomName+".mp4")); err != nil {
+	// Clean up original file before updating media.Path
+	inputPath := media.Path
+	if err := os.Remove(inputPath); err != nil {
 		log.Printf("error deleting original file: %s", err)
 	}
+
+	media.Path = outputPath
+	media.FileName = outputFileName
 
 	return nil
 }


### PR DESCRIPTION
## Summary

- `convertIntelligent` tried to delete the original UUID-named file (`tmpDir/UUID.mp4`), but `renameToReadableName` had already renamed it to a human-readable path. The `os.Remove` silently failed and the pre-conversion file was never cleaned up, leaking disk space on every conversion.
- Fix: delete `media.Path` (the actual current file) instead of the hardcoded UUID path.

## Reproduction

1. Send a video URL that requires conversion (e.g. VP9/AV1 codec)
2. The video gets downloaded, renamed to a readable title, then converted
3. After conversion, `tmpDir/Title.mp4` (the pre-conversion file) remains on disk
4. Files accumulate until the process exits

## Change

In `convertIntelligent` (`video.go`), save `media.Path` before overwriting it and use that for cleanup, instead of reconstructing the UUID-based path that no longer exists after `renameToReadableName`.