### PR TITLE
Fix sanitizeFileName truncating multi-byte UTF-8 characters

### DIFF
--- a/video.go
+++ b/video.go
@@ -360,9 +360,10 @@ func sanitizeFileName(title string) string {
 	}
 
 	// Aggressive truncation at 100 chars for mobile display
-	if len(sanitized) > 100 {
+	runes := []rune(sanitized)
+	if len(runes) > 100 {
 		// Try to truncate at word boundary
-		truncated := sanitized[:100]
+		truncated := string(runes[:100])
 		if lastSpace := strings.LastIndex(truncated, " "); lastSpace > 70 {
 			sanitized = truncated[:lastSpace]
 		} else {

--- a/video_test.go
+++ b/video_test.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -861,6 +862,74 @@ func TestIsAudioStreamBetter(t *testing.T) {
 	// Fewer channels should lose even with higher bitrate
 	if isAudioStreamBetter(stereoHighBitrate, surround) {
 		t.Error("2 channels should not be better than 6 channels regardless of bitrate")
+	}
+}
+
+func TestSanitizeFileName(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "simple title",
+			input:    "My Video",
+			expected: "My Video",
+		},
+		{
+			name:     "title with unsafe characters",
+			input:    "My/Video:Test|File",
+			expected: "My-Video-Test-File",
+		},
+		{
+			name:     "title with removed characters",
+			input:    "What? Why* How",
+			expected: "What Why How",
+		},
+		{
+			name:     "title with control characters",
+			input:    "Hello\x00World\x1F",
+			expected: "HelloWorld",
+		},
+		{
+			name:     "title with leading/trailing dots and spaces",
+			input:    "  ..My Video.. ",
+			expected: "My Video",
+		},
+		{
+			name:     "title with multiple spaces",
+			input:    "My   Video   Title",
+			expected: "My Video Title",
+		},
+		{
+			name:     "title that sanitizes to empty",
+			input:    "???***",
+			expected: "",
+		},
+		{
+			name:     "long ASCII title truncated at word boundary",
+			input:    "This is a very long video title that needs to be truncated because it exceeds the maximum allowed character limit for filenames",
+			expected: "This is a very long video title that needs to be truncated because it exceeds the maximum allowed",
+		},
+		{
+			name:     "long multibyte title truncates by characters not bytes",
+			input:    strings.Repeat("日本語", 40),       // 120 CJK characters, 360 bytes
+			expected: strings.Repeat("日本語", 33) + "日", // 100 characters (no spaces so no word boundary truncation)
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := sanitizeFileName(tt.input)
+			if result != tt.expected {
+				t.Errorf("sanitizeFileName(%q) = %q, expected %q", tt.input, result, tt.expected)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- `sanitizeFileName` used `len()` and byte-level slicing to truncate titles at 100 characters, but `len()` counts bytes in Go. For multi-byte UTF-8 titles (CJK, emoji, Cyrillic, etc.) this could split a rune in half, producing an invalid UTF-8 filename.
- Fix: convert to `[]rune` for character-level truncation.
- Added `TestSanitizeFileName` with table-driven tests covering edge cases including a multi-byte truncation case that would have failed before this fix.